### PR TITLE
LOC - calibration on start

### DIFF
--- a/src/Framework/loc/src/component/ComponentMain.cpp
+++ b/src/Framework/loc/src/component/ComponentMain.cpp
@@ -37,7 +37,10 @@ void ComponentMain::performEstimation()
         {
             if (_this->dyn_conf.init)
             {
-                _this->_estimator.calibrate(_this->dyn_conf.calMeas);
+                if (_this->dyn_conf.calMeas > 100)
+                    _this->_estimator.calibrate(10);
+                else
+                    _this->_estimator.calibrate(_this->dyn_conf.calMeas);
                 _this->dyn_conf.init= false;
             }
 			/* Perform the estimatior process*/

--- a/src/Framework/loc/src/component/ekf_class.cpp
+++ b/src/Framework/loc/src/component/ekf_class.cpp
@@ -8,7 +8,7 @@
 
 const char frame_name[10] = "ODOM";
 
-ekf::ekf() : _Egps(100),_Eimu(100)
+ekf::ekf() : _Egps(20),_Eimu(20)
 {
 	//ros::param::set("/LOC/Ready",0); 
 	_ready = 0;
@@ -34,6 +34,7 @@ ekf::ekf() : _Egps(100),_Eimu(100)
 
 	this->gas_pedal_state = 0;
 	this->last_pose = this->estimatedPose;
+    this->calibrate(20);
 }
 
 ekf::~ekf()

--- a/src/Framework/loc/src/component/userHeader.h
+++ b/src/Framework/loc/src/component/userHeader.h
@@ -25,8 +25,8 @@
  *
  */
 
-#define _init_latitude 31.2622 //_init_latitue - Recommended for debugging mode - end value of -1 to turn off
-#define _init_longitude 34.803611 //_init_longitude - Recommended for debugging mode - end value of -1 to turn off
+#define _init_latitude -1 //_init_latitue - Recommended for debugging mode - end value of -1 to turn off
+#define _init_longitude -1 //_init_longitude - Recommended for debugging mode - end value of -1 to turn off
 /* Initial position
  * In the case that noise is added, 100 reading of the GPS and IMU are taken to estimate the initial position of the vehicle for gazebo reference.
  * In any case the mean of the latitude and longitude received from the GPS will not be identical to the true location of the vehicle. This will lead to a constant bias error.


### PR DESCRIPTION
Now the LOC will perform GPS calibration on start.
You can recalibrate using the dynamic reconfiguration tool in RQT
