### PR TITLE
topics:

### DIFF
--- a/src/Framework/loc/src/component/ComponentMain.cpp
+++ b/src/Framework/loc/src/component/ComponentMain.cpp
@@ -27,7 +27,7 @@ ComponentMain::ComponentMain(int argc,char** argv)	: _inited(init(argc, argv))
 	_sub_PositionUpdate=ros::Subscriber(_nh.subscribe("/OCU/PositionUpdate", 10, &ComponentMain::handlePositionUpdate,this));
 	_sub_GPS=ros::Subscriber(_nh.subscribe("/SENSORS/GPS", 10, &ComponentMain::handleGPS,this));
 	_sub_INS=ros::Subscriber(_nh.subscribe("/SENSORS/INS", 10, &ComponentMain::handleINS,this));
-	_sub_GpsSpeed=ros::Subscriber(_nh.subscribe("/SENSORS/GPS/SpeedVec", 10, &ComponentMain::handleGpsSpeed,this));
+	_sub_GpsSpeed=ros::Subscriber(_nh.subscribe("/SENSORS/GPS/Speed", 10, &ComponentMain::handleGpsSpeed,this));
 	_pub_Location=ros::Publisher(_nh.advertise<geometry_msgs::PoseWithCovarianceStamped>("/LOC/Pose",10));
 	_pub_PerVelocity=ros::Publisher(_nh.advertise<geometry_msgs::TwistStamped>("/LOC/Velocity",10));
 	_pub_diagnostic=ros::Publisher(_nh.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics",100));

--- a/src/Framework/shiffon2ros/src/component/ComponentMain.cpp
+++ b/src/Framework/shiffon2ros/src/component/ComponentMain.cpp
@@ -39,8 +39,7 @@ ComponentMain::ComponentMain(int argc,char** argv)
 
 	_pub_GPSPose=ros::Publisher(_nh.advertise<sensor_msgs::NavSatFix>("/SENSORS/GPS",10));
 	_pub_INS=ros::Publisher(_nh.advertise<sensor_msgs::Imu>("/SENSORS/INS",10));
-	_pub_GpsSpeed=ros::Publisher(_nh.advertise<robil_msgs::GpsSpeed>("/SENSORS/GPS/Speed",10));
-	_pub_GpsSpeedVec=ros::Publisher(_nh.advertise<sensor_msgs::NavSatFix>("/SENSORS/GPS/SpeedVec",10));
+	_pub_GpsSpeed=ros::Publisher(_nh.advertise<sensor_msgs::NavSatFix>("/SENSORS/GPS/Speed",10));
 	_pub_diagnostic=ros::Publisher(_nh.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics",100));
 //	_maintains.add_thread(new boost::thread(boost::bind(&ComponentMain::heartbeat,this)));
     //Replace the thread group with a simple pthread because there is a SIGEV otherwise
@@ -155,23 +154,15 @@ void ComponentMain::ReadAndPub_ShiphonGpsSpeed() {
 	GpsSpeed_msg.speed = sqrt(East_vel*East_vel + North_vel*North_vel + Down_vel*Down_vel);
 	GpsSpeed_msg.header.stamp = ros::Time::now();
 */
-	publishGpsSpeed(GpsSpeed_msg);
 
 	config::SHIFFON2ROS::pub::GPS GpsSpeedVec_msg;
 	GpsSpeedVec_msg.latitude  = (_shiphonCtrl->get_PERIODIC100HZMESSAGE()).Velocity_north_Egi;
 	GpsSpeedVec_msg.longitude = (_shiphonCtrl->get_PERIODIC100HZMESSAGE()).Velocity_East_Egi;
 	GpsSpeedVec_msg.altitude  = -(_shiphonCtrl->get_PERIODIC100HZMESSAGE()).Velocity_down_Egi;
 	GpsSpeedVec_msg.header.stamp = ros::Time::now();
-	_pub_GpsSpeedVec.publish(GpsSpeedVec_msg);
+	_pub_GpsSpeed.publish(GpsSpeedVec_msg);
 
 }
-
-void ComponentMain::publishGpsSpeed(config::SHIFFON2ROS::pub::GpsSpeed& msg)
-{
-	_pub_GpsSpeed.publish(msg);
-}
-	
-
 
 void ComponentMain::publishTransform(const tf::Transform& _tf, std::string srcFrame, std::string distFrame){
 	//static tf::TransformBroadcaster br;

--- a/src/Framework/shiffon2ros/src/component/ComponentMain.h
+++ b/src/Framework/shiffon2ros/src/component/ComponentMain.h
@@ -28,7 +28,6 @@ class ComponentMain {
 		ros::Publisher  _pub_GPSPose;
 		ros::Publisher  _pub_INS;
 		ros::Publisher  _pub_GpsSpeed;
-		ros::Publisher  _pub_GpsSpeedVec;
 
 		string IPADDR;
 


### PR DESCRIPTION
removing '/SENSORS/GPS/Speed' topic (velocity in real number).

changing the name of '/SENSORS/GPS/SpeedVec' to '/SENSORS/GPS/Speed' (like the previous topic that we removed now).
the new topic publish a vector with directions velocities.

Signed-off-by: Akiva Cohen <akiva3@gmail.com>