### PR TITLE
PER - added acceleration filter for IBEO

### DIFF
--- a/src/Framework/per/cfg/config.cfg
+++ b/src/Framework/per/cfg/config.cfg
@@ -16,5 +16,6 @@ gen.add("convolution_size", int_t, 0,"convolution size for type calculation", 2,
 gen.add("convolution_type", str_t, 0, "For non linear convolution. Not in use yet!!!", "1,2,1")
 gen.add("obstacle_threshold", double_t, 0, "Obstacle thresholding - 0=everything is a threshold", 0.10, 0, 2)
 gen.add("filterPoints", double_t, 0, "Number of points in moving average filter", 0.9, 0, 1)
-gen.add("pitch_filter", double_t, 0, "Threshold of pitch to discard IBEO reading", 0.005, 0, 1)
+gen.add("pitch_filter", double_t, 0, "Threshold of pitch to discard IBEO reading", 0.37, 0, 1)
+gen.add("pitch_filter_timeout", double_t, 0, "How long to stop IBEO sensor reading (in sec)", 0.0, 0.0, 1.0)
 exit(gen.generate(PACKAGE, "per", "config"))

--- a/src/Framework/per/src/component/ComponentMain.cpp
+++ b/src/Framework/per/src/component/ComponentMain.cpp
@@ -102,16 +102,19 @@ void ComponentMain::handlePerVelocity(const config::PER::sub::PerVelocity& msg)
 void ComponentMain::handleSensorINS(const config::PER::sub::SensorINS& msg)
 {
     _imuData = msg;
-    tf::Quaternion q(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
-    tf::Matrix3x3 m(q);
-    double roll, pitch, yaw;
-    m.getRPY(roll, pitch, yaw);
-    double acc2 = msg.linear_acceleration.x * msg.linear_acceleration.x + msg.linear_acceleration.y * msg.linear_acceleration.y;
-//    cout << msg.angular_velocity << endl;
-    if (abs(pitch) > _dyn_conf.pitch_filter)
-        _should_pub = true;
+    double pitch = msg.linear_acceleration.x * msg.linear_acceleration.x + msg.linear_acceleration.y * msg.linear_acceleration.y;
+
+    if (sqrt(pitch) / 10.0 > _dyn_conf.pitch_filter)
+    {
+        _should_pub = false;
+        _should_pub_timeout.stamp = ros::Time::now();
+    }
     else
-        _should_pub = true;
+    {
+        if (!_should_pub)
+            if (ros::Time::now().toSec() - _should_pub_timeout.stamp.toSec() > _dyn_conf.pitch_filter_timeout)
+                _should_pub = true;
+    }
 
 //    cout << "got INS\n";
 //    config::PER::pub::INS msg2;

--- a/src/Framework/per/src/component/ComponentMain.h
+++ b/src/Framework/per/src/component/ComponentMain.h
@@ -107,6 +107,7 @@ private:
       sensor_msgs::NavSatFix _gpsData;
       HeightMap* height_map;
       bool _should_pub;
+      std_msgs::Header _should_pub_timeout;
 
       
       


### PR DESCRIPTION
If the acceleration rises due to a step or a bump,
IBEO readings will be filtered out.

Filter can be adjusted using the 'pitch_filter' parameter in DR
(Dynamic Reconfiguration).

Also, a timeout for the filter is optional also
by changing the parameter in DR (Defualt: 0.0 second timeout).