### PR TITLE
Critical change that should make our lives easier...

### DIFF
--- a/src/Simulation/bobcat_model/sdf_models/bobcat_tracked/model.sdf
+++ b/src/Simulation/bobcat_model/sdf_models/bobcat_tracked/model.sdf
@@ -565,7 +565,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_left" type="gearbox"><parent>back_left_wheel</parent><child>cogwheel_left</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
     <link name='cogwheel_right'>
@@ -613,7 +613,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--WHEELS-->
     <link name='back_left_wheel'>
@@ -667,7 +667,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='back_right_wheel'>
     <self_collide>0</self_collide>
@@ -720,7 +720,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_right" type="gearbox"><parent>back_right_wheel</parent><child>cogwheel_right</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
     <link name='front_left_wheel'>
@@ -774,7 +774,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='front_right_wheel'>
     <self_collide>0</self_collide>
@@ -827,10 +827,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_back_right'>
     <self_collide>0</self_collide>
-      <pose>-1.15 -0.65 -0.025 0 0 0</pose>
+      <pose>-1.16582 -0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -879,11 +880,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_mid_right'>
     <self_collide>0</self_collide>
-      <pose>-0.81 -0.65 -0.025 0 0 0</pose>
+      <pose>-0.79545 -0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -932,11 +933,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_front_right'>
     <self_collide>0</self_collide>
-      <pose>-0.46 -0.65 -0.025 0 0 0</pose>
+      <pose>-0.42447 -0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -985,11 +986,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_back_left'>
     <self_collide>0</self_collide>
-      <pose>-1.15 0.65 -0.025 0 0 0</pose>
+      <pose>-1.16582 0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -1038,11 +1039,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_mid_left'>
     <self_collide>0</self_collide>
-      <pose>-0.81 0.65 -0.025 0 0 0</pose>
+      <pose>-0.79545 0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -1091,11 +1092,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_front_left'>
     <self_collide>0</self_collide>
-      <pose>-0.46 0.65 -0.025 0 0 0</pose>
+      <pose>-0.42447 0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -1144,7 +1145,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <plugin name="bobcat_tracked_drive_control" filename="libbobcat_tracked_drive_plugin.so"/>
     <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">

--- a/src/Simulation/bobcat_model/sdf_models/bobcat_tracked_static_arm/model.sdf
+++ b/src/Simulation/bobcat_model/sdf_models/bobcat_tracked_static_arm/model.sdf
@@ -138,7 +138,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_left" type="gearbox"><parent>back_left_wheel</parent><child>cogwheel_left</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
 
@@ -187,7 +187,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
 
@@ -195,7 +195,7 @@
     <!--WHEELS-->
     <link name='back_left_wheel'>
     <self_collide>0</self_collide>
-      <pose>-1.53739 0.650 0.1 0 0 0</pose>
+      <pose>-1.53739 0.63 0.1 0  0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -244,12 +244,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='back_right_wheel'>
     <self_collide>0</self_collide>
-      <pose>-1.535 -0.650 0.1 0 0 0</pose>
+      <pose>-1.535 -0.63 0.1 0  0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -298,13 +298,13 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_right" type="gearbox"><parent>back_right_wheel</parent><child>cogwheel_right</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
 
     <link name='front_left_wheel'>
     <self_collide>0</self_collide>
-      <pose>-0.0535 0.655 0.1 0 0 0</pose>
+      <pose>-0.0535 0.63 0.1 0  0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -353,12 +353,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='front_right_wheel'>
     <self_collide>0</self_collide>
-      <pose>-0.0535 -0.65 0.1 0 0 0</pose>
+      <pose>-0.0535 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -407,15 +407,13 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
-    
-    
-    
-    
+
     <link name='roller_back_right'>
     <self_collide>0</self_collide>
-      <pose>-1.15 -0.65 0.1 0 0 0</pose>
+      <pose>-1.16582 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -464,12 +462,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_mid_right'>
     <self_collide>0</self_collide>
-      <pose>-0.81 -0.65 0.1 0 0 0</pose>
+      <pose>-0.79545 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -518,12 +516,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_front_right'>
     <self_collide>0</self_collide>
-      <pose>-0.46 -0.65 0.1 0 0 0</pose>
+      <pose>-0.42447 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -572,12 +570,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_back_left'>
     <self_collide>0</self_collide>
-      <pose>-1.15 0.65 0.1 0 0 0</pose>
+      <pose>-1.16582 0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -626,12 +624,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_mid_left'>
     <self_collide>0</self_collide>
-      <pose>-0.81 0.65 0.1 0 0 0</pose>
+      <pose>-0.79545 0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -680,12 +678,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_front_left'>
     <self_collide>0</self_collide>
-      <pose>-0.46 0.65 0.1 0 0 0</pose>
+      <pose>-0.42447 0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -734,7 +732,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
 

--- a/src/Simulation/bobcat_model/src/bobcat_tracked_drive_plugin.cc
+++ b/src/Simulation/bobcat_model/src/bobcat_tracked_drive_plugin.cc
@@ -34,7 +34,7 @@
 
 
 // Platform Constants
-#define WHEELS_BASE 1.32
+#define WHEELS_BASE 1.26
 #define WHEEL_DIAMETER 0.4
 #define MAX_PLAT_ROTATION_SPEED 1.5
 

--- a/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_arm_empty.world
+++ b/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_arm_empty.world
@@ -26,8 +26,8 @@
           <sor>1.4</sor>
         </solver>
         <constraints>
-          <cfm>0.0001</cfm>
-          <erp>0.02</erp>
+          <cfm>0.0</cfm>
+          <erp>0.2</erp>
           <contact_max_correcting_vel>100</contact_max_correcting_vel>
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>

--- a/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds.world
+++ b/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds.world
@@ -25,8 +25,8 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
-					<erp>0.02</erp>
+					<cfm>0</cfm>
+					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>
 				</constraints>

--- a/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds2.world
+++ b/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds2.world
@@ -25,8 +25,8 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
-					<erp>0.02</erp>
+					<cfm>0</cfm>
+					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>
 				</constraints>

--- a/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_empty.world
+++ b/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_empty.world
@@ -26,8 +26,8 @@
           <sor>1.4</sor>
         </solver>
         <constraints>
-          <cfm>0.0001</cfm>
-          <erp>0.02</erp>
+          <cfm>0.000</cfm>
+          <erp>0.2</erp>
           <contact_max_correcting_vel>100</contact_max_correcting_vel>
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>

--- a/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_stair.world
+++ b/src/Simulation/bobcat_model/worlds/bobcat_tracked_static_worlds/bobcat_tracked_static_arm_stair.world
@@ -31,8 +31,8 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
-					<erp>0.02</erp>
+					<cfm>0</cfm>
+					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>
 				</constraints>

--- a/src/Simulation/live_bobcat/sdf_models/bobcat_tracked/model.sdf
+++ b/src/Simulation/live_bobcat/sdf_models/bobcat_tracked/model.sdf
@@ -565,7 +565,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_left" type="gearbox"><parent>back_left_wheel</parent><child>cogwheel_left</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
     <link name='cogwheel_right'>
@@ -613,7 +613,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--WHEELS-->
     <link name='back_left_wheel'>
@@ -667,7 +667,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='back_right_wheel'>
     <self_collide>0</self_collide>
@@ -720,7 +720,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_right" type="gearbox"><parent>back_right_wheel</parent><child>cogwheel_right</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
     <link name='front_left_wheel'>
@@ -774,7 +774,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='front_right_wheel'>
     <self_collide>0</self_collide>
@@ -827,10 +827,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_back_right'>
     <self_collide>0</self_collide>
-      <pose>-1.15 -0.65 -0.025 0 0 0</pose>
+      <pose>-1.16582 -0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -879,11 +880,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_mid_right'>
     <self_collide>0</self_collide>
-      <pose>-0.81 -0.65 -0.025 0 0 0</pose>
+      <pose>-0.79545 -0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -932,11 +933,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_front_right'>
     <self_collide>0</self_collide>
-      <pose>-0.46 -0.65 -0.025 0 0 0</pose>
+      <pose>-0.42447 -0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -985,11 +986,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_back_left'>
     <self_collide>0</self_collide>
-      <pose>-1.15 0.65 -0.025 0 0 0</pose>
+      <pose>-1.16582 0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -1038,11 +1039,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_mid_left'>
     <self_collide>0</self_collide>
-      <pose>-0.81 0.65 -0.025 0 0 0</pose>
+      <pose>-0.79545 0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -1091,11 +1092,11 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <link name='roller_front_left'>
     <self_collide>0</self_collide>
-      <pose>-0.46 0.65 -0.025 0 0 0</pose>
+      <pose>-0.42447 0.65 -0.025 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -1144,7 +1145,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <plugin name="bobcat_tracked_drive_control" filename="libbobcat_tracked_drive_plugin.so"/>
     <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">

--- a/src/Simulation/live_bobcat/sdf_models/bobcat_tracked_static_arm/model.sdf
+++ b/src/Simulation/live_bobcat/sdf_models/bobcat_tracked_static_arm/model.sdf
@@ -91,7 +91,8 @@
       </collision>
     </link>
     
-    <!--COGWHEELS-->
+    
+   <!--COGWHEELS-->
     <link name='cogwheel_left'>
       <pose>-1.35 0.655 0.435 0 0 0</pose>
       <inertial>
@@ -137,7 +138,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_left" type="gearbox"><parent>back_left_wheel</parent><child>cogwheel_left</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
 
@@ -186,7 +187,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
 
@@ -194,7 +195,7 @@
     <!--WHEELS-->
     <link name='back_left_wheel'>
     <self_collide>0</self_collide>
-      <pose>-1.53739 0.650 0.1 0 0 0</pose>
+      <pose>-1.53739 0.63 0.1 0  0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -243,12 +244,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='back_right_wheel'>
     <self_collide>0</self_collide>
-      <pose>-1.535 -0.650 0.1 0 0 0</pose>
+      <pose>-1.535 -0.63 0.1 0  0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -297,13 +298,13 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
     <!--<joint name="gear_right" type="gearbox"><parent>back_right_wheel</parent><child>cogwheel_right</child><gearbox_ratio>-1</gearbox_ratio><gearbox_reference_body>body</gearbox_reference_body><axis><xyz>0.000000 1.000000 0.000000</xyz></axis><axis2><xyz>0.000000 1.000000 0.000000</xyz></axis2></joint>-->
 
     <link name='front_left_wheel'>
     <self_collide>0</self_collide>
-      <pose>-0.0535 0.655 0.1 0 0 0</pose>
+      <pose>-0.0535 0.63 0.1 0  0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -352,12 +353,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='front_right_wheel'>
     <self_collide>0</self_collide>
-      <pose>-0.0535 -0.65 0.1 0 0 0</pose>
+      <pose>-0.0535 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -406,15 +407,13 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
-    
-    
-    
-    
+
     <link name='roller_back_right'>
     <self_collide>0</self_collide>
-      <pose>-1.15 -0.65 0.1 0 0 0</pose>
+      <pose>-1.16582 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -463,12 +462,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_mid_right'>
     <self_collide>0</self_collide>
-      <pose>-0.81 -0.65 0.1 0 0 0</pose>
+      <pose>-0.79545 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -517,12 +516,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_front_right'>
     <self_collide>0</self_collide>
-      <pose>-0.46 -0.65 0.1 0 0 0</pose>
+      <pose>-0.42447 -0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -571,12 +570,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_back_left'>
     <self_collide>0</self_collide>
-      <pose>-1.15 0.65 0.1 0 0 0</pose>
+      <pose>-1.16582 0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -625,12 +624,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_mid_left'>
     <self_collide>0</self_collide>
-      <pose>-0.81 0.65 0.1 0 0 0</pose>
+      <pose>-0.79545 0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -679,12 +678,12 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
     <link name='roller_front_left'>
     <self_collide>0</self_collide>
-      <pose>-0.46 0.65 0.1 0 0 0</pose>
+      <pose>-0.42447 0.63 0.1 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>50</mass>
@@ -733,7 +732,7 @@
         </dynamics>
         <xyz>0 1 0</xyz>
       </axis>
-      <!--<physics><ode><cfm>0.001</cfm><erp>0.01</erp></ode></physics>-->
+      <physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>
     </joint>
 
 

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds.world
@@ -25,8 +25,8 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
-					<erp>0.02</erp>
+					<cfm>0.0</cfm>
+					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>
 				</constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds2.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_Robil_TestingGrounds2.world
@@ -25,8 +25,8 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
-					<erp>0.02</erp>
+					<cfm>0.0</cfm>
+					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>
 				</constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_TestWorld.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_TestWorld.world
@@ -31,8 +31,8 @@
                     <sor>1.4</sor>
                 </solver>
                 <constraints>
-                    <cfm>0.0001</cfm>
-                    <erp>0.02</erp>
+                    <cfm>0.0</cfm>
+                    <erp>0.2</erp>
                     <contact_max_correcting_vel>100</contact_max_correcting_vel>
                     <contact_surface_layer>0.001</contact_surface_layer>
                 </constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_TestWorld4.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_TestWorld4.world
@@ -31,8 +31,8 @@
                     <sor>1.4</sor>
                 </solver>
                 <constraints>
-                    <cfm>0.0001</cfm>
-                    <erp>0.02</erp>
+                    <cfm>0.0</cfm>
+                    <erp>0.2</erp>
                     <contact_max_correcting_vel>100</contact_max_correcting_vel>
                     <contact_surface_layer>0.001</contact_surface_layer>
                 </constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_empty.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_empty.world
@@ -31,8 +31,8 @@
                     <sor>1.4</sor>
                 </solver>
                 <constraints>
-                    <cfm>0.0001</cfm>
-                    <erp>0.02</erp>
+                    <cfm>0.0</cfm>
+                    <erp>0.2</erp>
                     <contact_max_correcting_vel>100</contact_max_correcting_vel>
                     <contact_surface_layer>0.001</contact_surface_layer>
                 </constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_stair.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_static_arm_worlds/bobcat_tracked_static_arm_stair.world
@@ -31,7 +31,7 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
+					<cfm>0.0</cfm>
 					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_Robil_TestingGrounds.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_Robil_TestingGrounds.world
@@ -25,8 +25,8 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
-					<erp>0.02</erp>
+					<cfm>0.0</cfm>
+					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>
 				</constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_TestWorld.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_TestWorld.world
@@ -31,8 +31,8 @@
                     <sor>1.4</sor>
                 </solver>
                 <constraints>
-                    <cfm>0.0001</cfm>
-                    <erp>0.02</erp>
+                    <cfm>0.0</cfm>
+                    <erp>0.2</erp>
                     <contact_max_correcting_vel>100</contact_max_correcting_vel>
                     <contact_surface_layer>0.001</contact_surface_layer>
                 </constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_TestWorld4.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_TestWorld4.world
@@ -31,8 +31,8 @@
                     <sor>1.4</sor>
                 </solver>
                 <constraints>
-                    <cfm>0.0001</cfm>
-                    <erp>0.02</erp>
+                    <cfm>0.0</cfm>
+                    <erp>0.2</erp>
                     <contact_max_correcting_vel>100</contact_max_correcting_vel>
                     <contact_surface_layer>0.001</contact_surface_layer>
                 </constraints>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_empty.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_empty.world
@@ -31,7 +31,7 @@
                     <sor>1.4</sor>
                 </solver>
                 <constraints>
-                    <cfm>0.0001</cfm>
+                    <cfm>0.0</cfm>
                     <erp>0.2</erp>
                     <contact_max_correcting_vel>100</contact_max_correcting_vel>
                     <contact_surface_layer>0.001</contact_surface_layer>

--- a/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_stair.world
+++ b/src/Simulation/live_bobcat/worlds/bobcat_tracked_worlds/bobcat_tracked_stair.world
@@ -31,7 +31,7 @@
 					<sor>1.4</sor>
 				</solver>
 				<constraints>
-					<cfm>0.0001</cfm>
+					<cfm>0.0</cfm>
 					<erp>0.2</erp>
 					<contact_max_correcting_vel>100</contact_max_correcting_vel>
 					<contact_surface_layer>0.001</contact_surface_layer>


### PR DESCRIPTION
Implemented cfm and erp into the sdf model itself instead of in the world files.

Reset the world files to default cfm and erp.
Moved rollers to be equal distance apart (cleanup)
and moved all the wheels so they dont bulge out of the visual and be in the middle of the tracks.
Status: Virtual platform response is almost 1 to 1 with real bag files

CFM and ERP can now be smartly changed using the calculator here:
https://www.dropbox.com/s/8032xrecpfyncv7/ERP-CFM%20CALCULATOR.ods?dl=0
To easily change all the tracked models simultaneously use "Find and replace in all files" (shift+ctrl+h) in visual studio code on the robil2 directory.
For example:
replace "<physics><ode><cfm>0.0000658</cfm><erp>0.01315</erp></ode></physics>" 
with      "<physics><ode><cfm>0.0001</cfm><erp>0.02</erp></ode></physics>"
This will affect only the files of the tracked models across all models.

Signed-off-by: yossi2010 <yossicohen2000@gmail.com>